### PR TITLE
Fix compilation under C compilers.

### DIFF
--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -2231,7 +2231,7 @@ int decodeInstruction(struct InternalInstruction *insn,
 		DisassemblerMode mode)
 {
 	insn->reader = reader;
-	insn->readerArg = (const reader_info*)readerArg;
+	insn->readerArg = (const struct reader_info*)readerArg;
 	insn->startLocation = startLoc;
 	insn->readerCursor = startLoc;
 	insn->mode = mode;

--- a/arch/X86/X86DisassemblerDecoder.h
+++ b/arch/X86/X86DisassemblerDecoder.h
@@ -591,7 +591,7 @@ typedef struct InternalInstruction {
   /* Reader interface (C) */
   byteReader_t reader;
   /* Opaque value passed to the reader */
-  const reader_info* readerArg;
+  const struct reader_info* readerArg;
   /* The address of the next byte to read via the reader */
   uint64_t readerCursor;
 


### PR DESCRIPTION
The reader_info struct is not typedef'd, so the struct keyword is needed
when compiling with a C compiler.
